### PR TITLE
chore: add Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+  - "8"
+  - "10"
+cache: yarn
+git:
+  depth: 5


### PR DESCRIPTION
We should enable Travis CI to run tests for all pushes and pull requests.